### PR TITLE
Fix #7, #8: Add test coverage and configurable timeouts

### DIFF
--- a/hoot.go
+++ b/hoot.go
@@ -36,16 +36,69 @@ const (
 	version          = "0.0.4" // Define the version here
 
 	// Tip validation constants
-	minTipSats int64 = 1     // Minimum 1 sat
+	minTipSats int64 = 1      // Minimum 1 sat
 	maxTipSats int64 = 100000 // Maximum 100k sats (~$50-100 USD)
-
-	// Timeout configuration (configurable via environment variables)
-	relayConnectTimeout  = 10 * time.Second  // Default timeout for relay connections
-	queryTimeout         = 10 * time.Second  // Default timeout for queries
-	dmQueryTimeout       = 15 * time.Second  // Timeout for DM queries (longer due to decryption)
-	signEventTimeout     = 30 * time.Second  // Timeout for signing events (NIP-46)
-	publishTimeout       = 5 * time.Second   // Timeout for publishing to individual relays
 )
+
+// TimeoutConfig holds configurable timeout values
+type TimeoutConfig struct {
+	RelayConnect time.Duration
+	Query        time.Duration
+	DMQuery      time.Duration
+	SignEvent    time.Duration
+	Publish      time.Duration
+}
+
+// DefaultTimeouts returns the default timeout configuration
+func DefaultTimeouts() TimeoutConfig {
+	return TimeoutConfig{
+		RelayConnect: 10 * time.Second,
+		Query:        10 * time.Second,
+		DMQuery:       15 * time.Second,
+		SignEvent:     30 * time.Second,
+		Publish:       5 * time.Second,
+	}
+}
+
+// LoadTimeoutsFromEnv loads timeout configuration from environment variables
+func LoadTimeoutsFromEnv() TimeoutConfig {
+	cfg := DefaultTimeouts()
+
+	if v := os.Getenv("HOOT_RELAY_CONNECT_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			cfg.RelayConnect = d
+		}
+	}
+	if v := os.Getenv("HOOT_QUERY_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			cfg.Query = d
+		}
+	}
+	if v := os.Getenv("HOOT_DM_QUERY_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			cfg.DMQuery = d
+		}
+	}
+	if v := os.Getenv("HOOT_SIGN_EVENT_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			cfg.SignEvent = d
+		}
+	}
+	if v := os.Getenv("HOOT_PUBLISH_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			cfg.Publish = d
+		}
+	}
+
+	return cfg
+}
+
+// Global timeout configuration (loaded at startup)
+var timeouts TimeoutConfig
+
+func init() {
+	timeouts = LoadTimeoutsFromEnv()
+}
 
 var defaultRelays = []string{
 	"wss://relay.damus.io",
@@ -527,7 +580,7 @@ func listPosts(pubKey string) error {
 		Kinds:   []int{1},
 		Limit:   4,
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeouts.Query)
 	defer cancel()
 
 	var events []nostr.Event
@@ -584,7 +637,7 @@ func getFeedPosts() ([]tui.FeedPost, error) {
 		Kinds: []int{1},
 		Limit: 20,
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeouts.Query)
 	defer cancel()
 
 	var posts []tui.FeedPost
@@ -652,7 +705,7 @@ func getDMs(privateKey string) ([]tui.FeedPost, error) {
 		Kinds: []int{4}, // DMs are kind 4
 		Limit: 50,
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), dmQueryTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeouts.DMQuery)
 	defer cancel()
 
 	var dms []tui.FeedPost
@@ -731,7 +784,7 @@ func getReactions(eventID string) ([]tui.FeedPost, error) {
 		Tags:  nostr.TagMap{"e": []string{eventID}},
 		Limit: 20,
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeouts.Query)
 	defer cancel()
 
 	var reactions []tui.FeedPost
@@ -790,7 +843,7 @@ func publishPostTUI(content string) error {
 	// If NIP-46 session is active, use it
 	if nip46Session != nil {
 		event.PubKey = nip46Session.UserPublicKey
-		ctx, cancel := context.WithTimeout(context.Background(), signEventTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), timeouts.SignEvent)
 		defer cancel()
 		if err := nip46Session.SignEvent(ctx, &event); err != nil {
 			return fmt.Errorf("remote signing failed: %w", err)
@@ -807,7 +860,7 @@ func publishPostTUI(content string) error {
 	success := 0
 	var failedRelays []string
 	for _, url := range relays {
-		ctx, cancel := context.WithTimeout(context.Background(), publishTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), timeouts.Publish)
 		defer cancel()
 		relay, err := nostr.RelayConnect(ctx, url)
 		if err != nil {
@@ -848,7 +901,7 @@ func getProfile(pubKey string) error {
 		Kinds:   []int{0},
 		Limit:   1,
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeouts.Query)
 	defer cancel()
 
 	var profileEvent *nostr.Event
@@ -1011,7 +1064,7 @@ func findHandlers(kind int) ([]struct {
 		Kinds: []int{1984},
 		Tags:  nostr.TagMap{"k": []string{fmt.Sprintf("%d", kind)}},
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeouts.Query)
 	defer cancel()
 
 	var handlers []struct {
@@ -1260,7 +1313,7 @@ func extractLud16(pubKey string, relays []string) (string, error) {
 		Limit:   1,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeouts.Query)
 	defer cancel()
 
 	var profileEvent *nostr.Event

--- a/nip46/nip46_test.go
+++ b/nip46/nip46_test.go
@@ -1,0 +1,240 @@
+package nip46
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestGenerateConnectURI(t *testing.T) {
+	uri, session, err := GenerateConnectURI("wss://relay.damus.io", "test-app")
+	if err != nil {
+		t.Fatalf("GenerateConnectURI failed: %v", err)
+	}
+
+	if uri == "" {
+		t.Error("URI should not be empty")
+	}
+
+	if session == nil {
+		t.Fatal("Session should not be nil")
+	}
+
+	// Verify URI format: nostrconnect://<clientPubkey>?relay=<relay>&metadata=<json>
+	if len(uri) < 20 {
+		t.Errorf("URI seems too short: %s", uri)
+	}
+
+	// Check URI starts with correct scheme
+	if uri[:15] != "nostrconnect://" {
+		t.Errorf("URI should start with 'nostrconnect://', got: %s", uri[:15])
+	}
+
+	// Check session has required fields
+	if session.ClientPrivateKey == "" {
+		t.Error("Session should have ClientPrivateKey")
+	}
+	if session.ClientPublicKey == "" {
+		t.Error("Session should have ClientPublicKey")
+	}
+	if session.RelayURL != "wss://relay.damus.io" {
+		t.Errorf("Session RelayURL mismatch: got %s", session.RelayURL)
+	}
+}
+
+func TestGenerateConnectURIDifferentRelays(t *testing.T) {
+	relays := []string{
+		"wss://relay.damus.io",
+		"wss://relay.nostr.band",
+		"wss://nostr.wine",
+		"ws://localhost:8080",
+	}
+
+	for _, relay := range relays {
+		_, session, err := GenerateConnectURI(relay, "test")
+		if err != nil {
+			t.Errorf("Failed for relay %s: %v", relay, err)
+			continue
+		}
+
+		if session.RelayURL != relay {
+			t.Errorf("RelayURL mismatch: expected %s, got %s", relay, session.RelayURL)
+		}
+
+		// Each call should generate different keys
+		if session.ClientPrivateKey == "" {
+			t.Errorf("Empty private key for relay %s", relay)
+		}
+	}
+}
+
+func TestGenerateConnectURIEscaping(t *testing.T) {
+	// Test that special characters in app name are handled
+	_, session, err := GenerateConnectURI("wss://relay.example.com", "Test App & Co.")
+	if err != nil {
+		t.Fatalf("GenerateConnectURI failed: %v", err)
+	}
+
+	if session == nil {
+		t.Fatal("Session should not be nil")
+	}
+}
+
+func TestRequestJSON(t *testing.T) {
+	req := Request{
+		ID:     "test-123",
+		Method: "get_public_key",
+		Params: []interface{}{},
+	}
+
+	// Verify Request can be marshaled to JSON
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("Failed to marshal Request: %v", err)
+	}
+
+	if len(data) == 0 {
+		t.Error("Marshaled data should not be empty")
+	}
+
+	// Verify we can unmarshal back
+	var req2 Request
+	if err := json.Unmarshal(data, &req2); err != nil {
+		t.Fatalf("Failed to unmarshal: %v", err)
+	}
+
+	if req2.ID != req.ID {
+		t.Errorf("ID mismatch: expected %s, got %s", req.ID, req2.ID)
+	}
+	if req2.Method != req.Method {
+		t.Errorf("Method mismatch: expected %s, got %s", req.Method, req2.Method)
+	}
+}
+
+func TestResponseJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		json     string
+		expected Response
+	}{
+		{
+			name: "success response",
+			json: `{"id":"123","result":"abc123"}`,
+			expected: Response{
+				ID:     "123",
+				Result: "abc123",
+			},
+		},
+		{
+			name: "error response",
+			json: `{"id":"456","error":"rejected"}`,
+			expected: Response{
+				ID:    "456",
+				Error: "rejected",
+			},
+		},
+		{
+			name: "full response",
+			json: `{"id":"789","result":"success","error":""}`,
+			expected: Response{
+				ID:     "789",
+				Result: "success",
+				Error:  "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var resp Response
+			err := json.Unmarshal([]byte(tt.json), &resp)
+			if err != nil {
+				t.Fatalf("Failed to unmarshal: %v", err)
+			}
+
+			if resp.ID != tt.expected.ID {
+				t.Errorf("ID mismatch: expected %s, got %s", tt.expected.ID, resp.ID)
+			}
+			if resp.Result != tt.expected.Result {
+				t.Errorf("Result mismatch: expected %s, got %s", tt.expected.Result, resp.Result)
+			}
+			if resp.Error != tt.expected.Error {
+				t.Errorf("Error mismatch: expected %s, got %s", tt.expected.Error, resp.Error)
+			}
+		})
+	}
+}
+
+func TestSessionClose(t *testing.T) {
+	// Create a session without connecting
+	_, session, err := GenerateConnectURI("wss://relay.damus.io", "test")
+	if err != nil {
+		t.Fatalf("GenerateConnectURI failed: %v", err)
+	}
+
+	// Close should not panic even without active connection
+	session.Close()
+
+	// Multiple closes should be safe
+	session.Close()
+}
+
+func TestRequestMethods(t *testing.T) {
+	methods := []struct {
+		method string
+		params []interface{}
+	}{
+		{"get_public_key", []interface{}{}},
+		{"sign_event", []interface{}{`{"kind":1,"content":"test"}`}},
+		{"nip04_encrypt", []interface{}{"pubkey123", "secret message"}},
+		{"nip04_decrypt", []interface{}{"pubkey123", "encrypted"}},
+	}
+
+	for _, tt := range methods {
+		t.Run(tt.method, func(t *testing.T) {
+			req := Request{
+				ID:     "test-id",
+				Method: tt.method,
+				Params: tt.params,
+			}
+
+			data, err := json.Marshal(req)
+			if err != nil {
+				t.Fatalf("Failed to marshal %s request: %v", tt.method, err)
+			}
+
+			// Verify method is in output
+			if len(data) == 0 {
+				t.Errorf("Empty JSON for method %s", tt.method)
+			}
+
+			// Verify we can unmarshal back
+			var req2 Request
+			if err := json.Unmarshal(data, &req2); err != nil {
+				t.Errorf("Failed to unmarshal %s: %v", tt.method, err)
+			}
+
+			if req2.Method != tt.method {
+				t.Errorf("Method mismatch: expected %s, got %s", tt.method, req2.Method)
+			}
+		})
+	}
+}
+
+func TestResponseBothFields(t *testing.T) {
+	// Test response with both result and error (edge case)
+	jsonStr := `{"id":"test","result":"ok","error":"warning"}`
+
+	var resp Response
+	err := json.Unmarshal([]byte(jsonStr), &resp)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal: %v", err)
+	}
+
+	// Both should be preserved
+	if resp.Result != "ok" {
+		t.Errorf("Expected result 'ok', got %s", resp.Result)
+	}
+	if resp.Error != "warning" {
+		t.Errorf("Expected error 'warning', got %s", resp.Error)
+	}
+}

--- a/tui/tui_test.go
+++ b/tui/tui_test.go
@@ -1,0 +1,122 @@
+package tui
+
+import (
+	"testing"
+)
+
+func TestNewModel(t *testing.T) {
+	model := NewModel()
+
+	if model.screen != ScreenLogin {
+		t.Errorf("Expected initial screen to be ScreenLogin, got %d", model.screen)
+	}
+
+	if model.textInput.Focused() != true {
+		t.Error("TextInput should be focused initially")
+	}
+
+	if model.textInput.CharLimit != 256 {
+		t.Errorf("Expected CharLimit 256, got %d", model.textInput.CharLimit)
+	}
+}
+
+func TestScreenConstants(t *testing.T) {
+	// Verify screen constants are distinct
+	screens := map[string]Screen{
+		"Login":    ScreenLogin,
+		"QRLogin":  ScreenQRLogin,
+		"Home":     ScreenHome,
+		"Post":     ScreenPost,
+		"Feed":     ScreenFeed,
+		"DMs":      ScreenDMs,
+		"Replies":  ScreenReplies,
+		"Tip":      ScreenTip,
+		"Relays":   ScreenRelays,
+		"Profiles": ScreenProfiles,
+	}
+
+	seen := make(map[Screen]bool)
+	for name, screen := range screens {
+		if seen[screen] {
+			t.Errorf("Duplicate screen value: %s has value %d", name, screen)
+		}
+		seen[screen] = true
+	}
+
+	// Verify we have all expected screens
+	if len(screens) != 10 {
+		t.Errorf("Expected 10 screen types, got %d", len(screens))
+	}
+}
+
+func TestFeedPost(t *testing.T) {
+	post := FeedPost{
+		Author:    "npub1test",
+		Content:   "Hello world",
+		CreatedAt: "2h ago",
+	}
+
+	if post.Author != "npub1test" {
+		t.Errorf("Author mismatch: %s", post.Author)
+	}
+	if post.Content != "Hello world" {
+		t.Errorf("Content mismatch: %s", post.Content)
+	}
+	if post.CreatedAt != "2h ago" {
+		t.Errorf("CreatedAt mismatch: %s", post.CreatedAt)
+	}
+}
+
+func TestProfileInfo(t *testing.T) {
+	profile := ProfileInfo{
+		ID:        "profile-123",
+		Name:      "Test User",
+		PublicKey: "npub1abc123",
+	}
+
+	if profile.ID != "profile-123" {
+		t.Errorf("ID mismatch: %s", profile.ID)
+	}
+	if profile.Name != "Test User" {
+		t.Errorf("Name mismatch: %s", profile.Name)
+	}
+	if profile.PublicKey != "npub1abc123" {
+		t.Errorf("PublicKey mismatch: %s", profile.PublicKey)
+	}
+}
+
+func TestStyles(t *testing.T) {
+	// Verify styles are defined
+	if titleStyle.GetMarginBottom() != 1 {
+		t.Error("titleStyle should have margin bottom")
+	}
+
+	// These should not panic
+	_ = menuStyle.Render("test")
+	_ = selectedStyle.Render("test")
+	_ = inputStyle.Render("test")
+	_ = errorStyle.Render("test")
+	_ = successStyle.Render("test")
+}
+
+func TestModelInitialValues(t *testing.T) {
+	model := NewModel()
+
+	// Check initial state
+	if model.loggedIn {
+		t.Error("Model should not be logged in initially")
+	}
+
+	if model.publicKey != "" {
+		t.Error("PublicKey should be empty initially")
+	}
+
+	if model.privateKey != "" {
+		t.Error("PrivateKey should be empty initially")
+	}
+
+	// Check cursor starts at 0
+	if model.cursor != 0 {
+		t.Errorf("Expected cursor 0, got %d", model.cursor)
+	}
+}


### PR DESCRIPTION
## Changes

### Issue #7: Add test coverage for nip46 and tui packages

- **nip46/nip46_test.go**: Tests for:
  - GenerateConnectURI (multiple relays, escaping)
  - Request/Response JSON serialization
  - Session close safety
  - All NIP-46 request methods

- **tui/tui_test.go**: Tests for:
  - NewModel initialization
  - Screen constants validation
  - FeedPost and ProfileInfo structs
  - Style definitions

### Issue #8: Make timeouts configurable via environment variables

Replaced hardcoded timeout constants with a configurable `TimeoutConfig` struct:

```go
type TimeoutConfig struct {
    RelayConnect time.Duration
    Query        time.Duration
    DMQuery      time.Duration
    SignEvent    time.Duration
    Publish      time.Duration
}
```

**Environment variables:**
- `HOOT_RELAY_CONNECT_TIMEOUT` (default: 10s)
- `HOOT_QUERY_TIMEOUT` (default: 10s)
- `HOOT_DM_QUERY_TIMEOUT` (default: 15s)
- `HOOT_SIGN_EVENT_TIMEOUT` (default: 30s)
- `HOOT_PUBLISH_TIMEOUT` (default: 5s)

**Usage:**
```bash
HOOT_QUERY_TIMEOUT=30s hoot -feed
HOOT_DM_QUERY_TIMEOUT=1m hoot -dms
```

## Testing

All new tests pass:
```
ok  	hoot/nip46	0.024s
ok  	hoot/tui	0.007s
```