### PR TITLE
fix: add relay URL validation in loadRelays()

### DIFF
--- a/hoot.go
+++ b/hoot.go
@@ -293,6 +293,16 @@ func getConfigDir() string {
 	return filepath.Join(configDir, appName)
 }
 
+// isValidRelayURL checks if a URL is a valid websocket relay URL.
+// Only ws:// and wss:// schemes are accepted, and host must not be empty.
+func isValidRelayURL(urlStr string) bool {
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return false
+	}
+	return (u.Scheme == "wss" || u.Scheme == "ws") && u.Host != ""
+}
+
 // loadRelays attempts to read relay URLs from a local "relays.txt" file first,
 // if not found then it checks the config directory.
 func loadRelays() ([]string, error) {
@@ -313,6 +323,10 @@ func loadRelays() ([]string, error) {
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if line != "" && !strings.HasPrefix(line, "//") { // ignore commented lines
+			if !isValidRelayURL(line) {
+				log.Printf("Warning: skipping invalid relay URL: %s", line)
+				continue
+			}
 			relays = append(relays, line)
 		}
 	}


### PR DESCRIPTION
## Summary
- Add `isValidRelayURL()` to validate `ws://` and `wss://` schemes
- Skip invalid URLs with warning log message
- Prevents crashes from malformed relay URLs

## Test plan
- [x] `go build` passes
- [x] Validation tested with valid/invalid URLs
- [x] Empty hosts rejected
- [x] Non-websocket schemes rejected

Fixes #18